### PR TITLE
CONTRIBUTING: Switch from CLA to DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,28 @@
 Want to contribute? Great! First, read this page
 
-### Before you contribute
-Before we can use your code, you must sign the
-[HERE Contributor License Agreement](https://gist.github.com/heremaps-bot/dcb932a07b424f8ed68341054e7e3a53)
-(CLA), which triggers automatically when you make a pull request. 
-The CLA is necessary mainly because you own the
-copyright to your changes, even after your contribution becomes part of our
-codebase, so we need your permission to use and distribute your code. We also
-need to be sure of various other things -- for instance that you'll tell us if
-you know that your code infringes on other people's patents.
-Coordinating up front makes it much easier to avoid
-frustration later on.
-
-### Code reviews
+## Code Reviews
 All submissions, including submissions by project members, require review. We
-use Github pull requests for this purpose.
+use [Github pull requests](https://help.github.com/articles/about-pull-requests/) for this purpose.
 
+### Signing each Commit
+
+As part of filing a pull request we ask you to sign off the
+[Developer Certificate of Origin](https://developercertificate.org/) (DCO) in each commit.
+Any Pull Request with commits that are not signed off will be reject by the
+[DCO check](https://probot.github.io/apps/dco/).
+
+A DCO is lightweight way for a contributor to confirm that you wrote or otherwise have the right
+to submit code or documentation to a project. Simply add `Signed-off-by` as shown in the example below
+to indicate that you agree with the DCO.
+
+An example signed commit message:
+
+```
+    README.md: Fix minor spelling mistake
+
+    Signed-off-by: John Doe <john.doe@example.com>
+```
+
+Git has the `-s` flag that can sign a commit for you, see example below:
+
+`$ git commit -s -m 'README.md: Fix minor spelling mistake'`


### PR DESCRIPTION
Updating CONTRIBUTING.md to replace CLA with DCO which is required for all HERE OSS projects.

Signed-off-by: Thomas Steenbergen <thomas.steenbergen@here.com>